### PR TITLE
evt.nativeEvent.page{X, Y} to evt.nativeEvent.location{X, Y}

### DIFF
--- a/src/HoloColorPicker.js
+++ b/src/HoloColorPicker.js
@@ -18,8 +18,6 @@ export class HoloColorPicker extends Component {
       this.state.color = tinycolor(props.defaultColor).toHsv()
     }
     this._layout = { width: 0, height: 0, x: 0, y: 0 }
-    this._pageX = 0
-    this._pageY = 0
     this._onLayout = this._onLayout.bind(this)
     this._onSValueChange = this._onSValueChange.bind(this)
     this._onVValueChange = this._onVValueChange.bind(this)
@@ -71,16 +69,6 @@ export class HoloColorPicker extends Component {
     if (this.state.pickerSize !== pickerSize) {
       this.setState({ pickerSize })
     }
-    // layout.x, layout.y is always 0
-    // we always measure because layout is the same even though picker is moved on the page
-    InteractionManager.runAfterInteractions(() => {
-      // measure only after (possible) animation ended
-      this.refs.pickerContainer && this.refs.pickerContainer.measure((x, y, width, height, pageX, pageY) => {
-        // picker position in the screen
-        this._pageX = pageX
-        this._pageY = pageY
-      })
-    })
   }
 
   _computeHValue(x, y) {
@@ -104,11 +92,7 @@ export class HoloColorPicker extends Component {
   componentWillMount() {
     const handleColorChange = ({ x, y }) => {
       const { s, v } = this._getColor()
-      const marginLeft = (this._layout.width - this.state.pickerSize) / 2
-      const marginTop = (this._layout.height - this.state.pickerSize) / 2
-      const relativeX = x - this._pageX - marginLeft;
-      const relativeY = y - this._pageY - marginTop;
-      const h = this._computeHValue(relativeX, relativeY)
+      const h = this._computeHValue(x, y)
       this._onColorChange({ h, s, v })
     }
     this._pickerResponder = createPanResponder({

--- a/src/TriangleColorPicker.js
+++ b/src/TriangleColorPicker.js
@@ -94,11 +94,7 @@ export class TriangleColorPicker extends Component {
 
   _handleHColorChange({ x, y }) {
     const { s, v } = this._getColor()
-    const marginLeft = (this._layout.width - this.state.pickerSize) / 2
-    const marginTop = (this._layout.height - this.state.pickerSize) / 2
-    const relativeX = x - this._pageX - marginLeft;
-    const relativeY = y - this._pageY - marginTop;
-    const h = this._computeHValue(relativeX, relativeY)
+    const h = this._computeHValue(x, y)
     this._onColorChange({ h, s, v })
   }
 

--- a/src/TriangleColorPicker.js
+++ b/src/TriangleColorPicker.js
@@ -18,8 +18,6 @@ export class TriangleColorPicker extends Component {
       this.state.color = tinycolor(props.defaultColor).toHsv()
     }
     this._layout = { width: 0, height: 0, x: 0, y: 0 }
-    this._pageX = 0
-    this._pageY = 0
     this._onLayout = this._onLayout.bind(this)
     this._onSValueChange = this._onSValueChange.bind(this)
     this._onVValueChange = this._onVValueChange.bind(this)
@@ -71,16 +69,7 @@ export class TriangleColorPicker extends Component {
     if (this.state.pickerSize !== pickerSize) {
       this.setState({ pickerSize })
     }
-    // layout.x, layout.y is always 0
-    // we always measure because layout is the same even though picker is moved on the page
-    InteractionManager.runAfterInteractions(() => {
-      // measure only after (possible) animation ended
-      this.refs.pickerContainer && this.refs.pickerContainer.measure((x, y, width, height, pageX, pageY) => {
-        // picker position in the screen
-        this._pageX = pageX
-        this._pageY = pageY
-      })
-    })
+    
   }
 
   _computeHValue(x, y) {
@@ -103,11 +92,7 @@ export class TriangleColorPicker extends Component {
 
   _handleHColorChange({ x, y }) {
     const { s, v } = this._getColor()
-    const marginLeft = (this._layout.width - this.state.pickerSize) / 2
-    const marginTop = (this._layout.height - this.state.pickerSize) / 2
-    const relativeX = x - this._pageX - marginLeft;
-    const relativeY = y - this._pageY - marginTop;
-    const h = this._computeHValue(relativeX, relativeY)
+    const h = this._computeHValue(x, y)
     this._onColorChange({ h, s, v })
   }
 
@@ -153,14 +138,8 @@ export class TriangleColorPicker extends Component {
     const { pickerSize } = this.state
     const { triangleHeight, triangleWidth } = getPickerProperties(pickerSize)
 
-    const left = pickerSize / 2 - triangleWidth / 2
-    const top = pickerSize / 2 - 2 * triangleHeight / 3
-
-    // triangle relative coordinates
-    const marginLeft = (this._layout.width - this.state.pickerSize) / 2
-    const marginTop = (this._layout.height - this.state.pickerSize) / 2
-    const relativeX = x - this._pageX - marginLeft - left;
-    const relativeY = y - this._pageY - marginTop - top;
+    const relativeX = x - left;
+    const relativeY = y - top;
 
     // rotation
     const { h } = this._getColor()

--- a/src/TriangleColorPicker.js
+++ b/src/TriangleColorPicker.js
@@ -18,6 +18,8 @@ export class TriangleColorPicker extends Component {
       this.state.color = tinycolor(props.defaultColor).toHsv()
     }
     this._layout = { width: 0, height: 0, x: 0, y: 0 }
+    this._pageX = 0
+    this._pageY = 0
     this._onLayout = this._onLayout.bind(this)
     this._onSValueChange = this._onSValueChange.bind(this)
     this._onVValueChange = this._onVValueChange.bind(this)
@@ -92,7 +94,11 @@ export class TriangleColorPicker extends Component {
 
   _handleHColorChange({ x, y }) {
     const { s, v } = this._getColor()
-    const h = this._computeHValue(x, y)
+    const marginLeft = (this._layout.width - this.state.pickerSize) / 2
+    const marginTop = (this._layout.height - this.state.pickerSize) / 2
+    const relativeX = x - this._pageX - marginLeft;
+    const relativeY = y - this._pageY - marginTop;
+    const h = this._computeHValue(relativeX, relativeY)
     this._onColorChange({ h, s, v })
   }
 
@@ -137,7 +143,8 @@ export class TriangleColorPicker extends Component {
   _computeColorFromTriangle({ x, y }) {
     const { pickerSize } = this.state
     const { triangleHeight, triangleWidth } = getPickerProperties(pickerSize)
-
+    const left = pickerSize / 2 - triangleWidth / 2
+    const top = pickerSize / 2 - 2 * triangleHeight / 3
     const relativeX = x - left;
     const relativeY = y - top;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,13 +31,13 @@ export function createPanResponder({ onStart = fn, onMove = fn, onEnd = fn }) {
     onMoveShouldSetPanResponderCapture: fn,
     onPanResponderTerminationRequest: fn,
     onPanResponderGrant: (evt, state) => {
-      return onStart({ x: evt.nativeEvent.pageX, y: evt.nativeEvent.pageY }, evt, state)
+      return onStart({ x: evt.nativeEvent.locationX, y: evt.nativeEvent.locationY }, evt, state)
     },
     onPanResponderMove: (evt, state) => {
-      return onMove({ x: evt.nativeEvent.pageX, y: evt.nativeEvent.pageY }, evt, state)
+      return onMove({ x: evt.nativeEvent.locationX, y: evt.nativeEvent.locationY }, evt, state)
     },
     onPanResponderRelease: (evt, state) => {
-      return onEnd({ x: evt.nativeEvent.pageX, y: evt.nativeEvent.pageY }, evt, state)
+      return onEnd({ x: evt.nativeEvent.locationX, y: evt.nativeEvent.locationY }, evt, state)
     },
   })
 }


### PR DESCRIPTION
The picker doesn't works properly when it is in a **Animatid.View** with translate value. 
I think it's because **onLayout** doesn't call again when **translate{X, Y}** changed, so **picker._pageX** and **picker._pageY** are not changed but **nativeEvent.pageX** and **nativeEvent.pageY** are based on the root element.
I changed those to **nativeEvent.location{X, Y}** and it works well.

From [document](https://facebook.github.io/react-native/docs/panresponder.html):
> locationX - The X position of the touch, relative to the element
> locationY - The Y position of the touch, relative to the element
> pageX - The X position of the touch, relative to the root element
> pageY - The Y position of the touch, relative to the root element