### PR TITLE
Import PropTypes package separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-react": "^6.8.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "tinycolor2": "^1.4.1"
   }
 }

--- a/src/HoloColorPicker.js
+++ b/src/HoloColorPicker.js
@@ -1,9 +1,10 @@
-import React, { Component, PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 import { TouchableOpacity, Slider, View, Image, StyleSheet, InteractionManager, I18nManager } from 'react-native'
 import tinycolor from 'tinycolor2'
 import { createPanResponder } from './utils'
 
-export class HoloColorPicker extends Component {
+export class HoloColorPicker extends React.PureComponent {
 
   constructor(props, ctx) {
     super(props, ctx)

--- a/src/TriangleColorPicker.js
+++ b/src/TriangleColorPicker.js
@@ -1,9 +1,10 @@
-import React, { Component, PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 import { TouchableOpacity, View, Image, StyleSheet, InteractionManager, I18nManager } from 'react-native'
 import tinycolor from 'tinycolor2'
 import { createPanResponder, rotatePoint } from './utils'
 
-export class TriangleColorPicker extends Component {
+export class TriangleColorPicker extends React.PureComponent {
 
   constructor(props, ctx) {
     super(props, ctx)


### PR DESCRIPTION
More recent versions of React Native are using React 16 beta, which has removed PropTypes from the main package. You have to use the separate `prop-types` package now.