### PR TITLE
Recompute page-space origin coordinates every gesture

### DIFF
--- a/src/TriangleColorPicker.js
+++ b/src/TriangleColorPicker.js
@@ -188,17 +188,25 @@ export class TriangleColorPicker extends React.PureComponent {
 
   componentWillMount() {
     const handleColorChange = ({ x, y }) => {
-      if (this._changingHColor) {
-        this._handleHColorChange({ x, y })
-      } else {
-        this._handleSVColorChange({ x, y })
+      if (this._changingHColor !== undefined) {
+        if (this._changingHColor) {
+          this._handleHColorChange({ x, y })
+        } else {
+          this._handleSVColorChange({ x, y })
+        }
       }
     }
     this._pickerResponder = createPanResponder({
       onStart: ({ x, y }) => {
-        const { s, v } = this._computeColorFromTriangle({ x, y })
-        this._changingHColor = s > 1 || s < 0 || v > 1 || v < 0
-        handleColorChange({ x, y })
+        this._changingHColor = undefined
+        this.refs.pickerContainer && this.refs.pickerContainer.measure((measureX, measureY, width, height, pageX, pageY) => {
+          // picker position in the screen
+          this._pageX = pageX
+          this._pageY = pageY
+          const { s, v } = this._computeColorFromTriangle({ x, y })
+          this._changingHColor = s > 1 || s < 0 || v > 1 || v < 0
+          handleColorChange({ x, y })
+        })
       },
       onMove: handleColorChange,
     })


### PR DESCRIPTION
`onLayout` is only called when the position is changed within the parent container, but if the parent container itself moves, it's not called. This makes `this._page{X,Y}` be out of date. In my case, I have a draggable 'window' as the parent of the color picker and moving it around isn't updating `this_page{X,Y}`. This change makes it so `this_page{X,Y}` is computed whenever a new color picking gesture begins so that it's always up to date (unless the color picker moves while gesturing but we can take care of that later...).