### PR TITLE
Fix Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,21 @@
 declare module 'react-native-color-picker' {
   import * as React from 'react';
 
+  type HsvColor = { h: number; s: number; v: number };
+
   export interface IPicker {
-    color: string;
-    defaultColor: string | { h: number; s: number; v: number };
+    color: string | HsvColor;
+    defaultColor: string | HsvColor;
     oldColor?: string;
-    style: object;
-    onColorSelected: (selectedColor: { h: number; s: number; v: number }) => void;
-    onColorChange: (selectedColor: { h: number; s: number; v: number }) => void;
-    onOldColorSelected?: (oldColor: { h: number; s: number; v: number }) => void;
+    style?: object;
+    onColorSelected: (selectedColor: HsvColor) => void;
+    onColorChange: (selectedColor: HsvColor) => void;
+    onOldColorSelected?: (oldColor: HsvColor) => void;
     hideSliders?: boolean;
   }
 
   export const ColorPicker: React.ComponentType<IPicker>;
   export const TriangleColorPicker: React.ComponentType<IPicker>;
-  export const toHsv: (color: string) => { h: number; s: number; v: number };
-  export const fromHsv: (hsv: { h: number; s: number; v: number }) => string;
+  export const toHsv: (color: string) => HsvColor;
+  export const fromHsv: (hsv: HsvColor) => string;
 }


### PR DESCRIPTION
Improved typescript typings with the following:

* add hsv format to `color`
* pull out hsv shape into a reusable type
* made `style` optional
