### PR TITLE
Update HoloColorPicker.js

### DIFF
--- a/src/HoloColorPicker.js
+++ b/src/HoloColorPicker.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { TouchableOpacity, Slider, View, Image, StyleSheet, InteractionManager, I18nManager } from 'react-native'
+import { TouchableOpacity, View, Image, StyleSheet, InteractionManager, I18nManager } from 'react-native'
 import tinycolor from 'tinycolor2'
+import Slider from '@react-native-community/slider';
+
+
 import { createPanResponder } from './utils'
 
 export class HoloColorPicker extends React.PureComponent {


### PR DESCRIPTION
This file uses react native slider. Slider was split out from the core of React Native. To migrate to this module you need to follow the installation instructions @https://github.com/react-native-community/react-native-slider and download react native slider and then change your imports 
from:
import { Slider } from 'react-native';

to:
import Slider from '@react-native-community/slider';